### PR TITLE
Iterate and filter directly for files starting with Godeps

### DIFF
--- a/bin/gpm-all
+++ b/bin/gpm-all
@@ -22,13 +22,10 @@ EOF
 
 case "${1:-"install"}" in
   "install")
-    for file in *
+    for file in Godeps*
     do
-      if [[ $file =~ 'Godeps' ]]
-      then
         echo ">> [gpm-all] Installing dependencies in '$file'"
         gpm install $file
-      fi
     done
     ;;
   "version")


### PR DESCRIPTION
This will only iterate over files starting with `Godeps`, instead of iterating on all files in the current directory.
